### PR TITLE
[TravisCI] Removing nightly build as causing failures in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-composer.lock
 .idea/
 /vendor/
 composer.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+composer.lock
+.idea/
 /vendor/
 composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ php:
   - '5.6'
   - '7.0'
   - '7.1'
-  - 'nightly'
+  - '7.2'
+  - '7.3'
 install:
   - composer install
 script:

--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@ OpenExRt\Client
 
 [![Build Status](https://travis-ci.org/danbelden/open-exchange-rates.svg?branch=master)](https://travis-ci.org/danbelden/open-exchange-rates)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/danbelden/open-exchange-rates/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/danbelden/open-exchange-rates/?branch=master)
+[![Maintainability](https://api.codeclimate.com/v1/badges/5e7fc4fc1c3659fb3f39/maintainability)](https://codeclimate.com/github/danbelden/open-exchange-rates/maintainability)
 [![Latest Stable Version](https://poser.pugx.org/danbelden/open-exchange-rates/version.svg)](https://packagist.org/packages/danbelden/open-exchange-rates)
 [![Total Downloads](https://poser.pugx.org/danbelden/open-exchange-rates/downloads.svg)](https://packagist.org/packages/danbelden/open-exchange-rates)
 
-A PHP 5, wrapper for the [openexchangerates.org](https://openexchangerates.org) API.
+A PHP 5+, wrapper for the [openexchangerates.org](https://openexchangerates.org) API.
 
 # Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "authors": [
         {
             "name": "Dan Belden",
-            "email": "me@danbelden.com"
+            "email": "me@danbelden.com",
+            "homepage": "https://github.com/danbelden"
         }
     ],
     "type": "library",


### PR DESCRIPTION
https://travis-ci.org/danbelden/open-exchange-rates/builds/494387891
```
$ composer install
Loading composer repositories with package information
Updating dependencies (including require-dev)
Package operations: 18 installs, 0 updates, 0 removals
  - Installing symfony/yaml (v2.6.13): Downloading (100%)
  - Installing sebastian/version (1.0.6): Downloading (100%)
  - Installing sebastian/global-state (1.1.1): Downloading (100%)
  - Installing sebastian/recursion-context (1.0.5): Downloading (100%)
  - Installing sebastian/exporter (1.2.2): Downloading (100%)
  - Installing sebastian/environment (1.3.8): Downloading (100%)
  - Installing sebastian/diff (1.4.3): Downloading (100%)
  - Installing sebastian/comparator (1.2.4): Downloading (100%)
  - Installing doctrine/instantiator (1.0.5): Downloading (100%)
  - Installing phpunit/php-text-template (1.2.1): Downloading (100%)
  - Installing phpunit/phpunit-mock-objects (2.3.8): Downloading (100%)
  - Installing phpunit/php-timer (1.0.9): Downloading (100%)
  - Installing phpunit/php-file-iterator (1.4.5): Downloading (100%)
  - Installing phpunit/php-token-stream (1.4.12): Downloading (100%)
  - Installing phpunit/php-code-coverage (2.2.4): Downloading (100%)
  - Installing phpdocumentor/reflection-docblock (2.0.5): Downloading (100%)
  - Installing phpspec/prophecy (1.8.0): Downloading (100%)
  - Installing phpunit/phpunit (4.8.36): Downloading (100%)
sebastian/global-state suggests installing ext-uopz (*)
phpunit/php-code-coverage suggests installing ext-xdebug (>=2.2.1)
phpdocumentor/reflection-docblock suggests installing dflydev/markdown (~1.0)
phpdocumentor/reflection-docblock suggests installing erusev/parsedown (~1.0)
phpunit/phpunit suggests installing phpunit/php-invoker (~1.1)
Package phpunit/phpunit-mock-objects is abandoned, you should avoid using it. No replacement was suggested.
Writing lock file
Generating autoload files
0.10s$ vendor/bin/phpunit
PHP Fatal error:  Uncaught Error: Call to undefined function each() in /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/src/Util/Getopt.php:38
Stack trace:
#0 /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/src/TextUI/Command.php(240): PHPUnit_Util_Getopt::getopt(Array, 'd:c:hv', Array)
#1 /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/src/TextUI/Command.php(111): PHPUnit_TextUI_Command->handleArguments(Array)
#2 /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/src/TextUI/Command.php(100): PHPUnit_TextUI_Command->run(Array, true)
#3 /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/phpunit(52): PHPUnit_TextUI_Command::main()
#4 {main}
  thrown in /home/travis/build/danbelden/open-exchange-rates/vendor/phpunit/phpunit/src/Util/Getopt.php on line 38
```