### PR TITLE
[TravisCI] Verbosely define platform for each PHP build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 language: php
-php:
-  - '5.4'
-  - '5.5'
-  - '5.6'
-  - '7.0'
-  - '7.1'
-  - '7.2'
-  - '7.3'
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.4
+      dist: trusty
+    - php: 5.5
+      dist: trusty
+    - php: 5.6
+      dist: trusty
+    - php: 7.0
+      dist: trusty
+    - php: 7.1
+      dist: trusty
+    - php: 7.2
+      dist: trusty
+    - php: 7.3
+      dist: trusty
 install:
   - composer install
 script:


### PR DESCRIPTION
- https://travis-ci.org/danbelden/open-exchange-rates/builds/564288674

```
Worker information
hostname: 31a78478-997f-4882-b851-2e78d68e28ff@1.worker-org-78c6f46d9c-l8j8r.gce-production-1
version: v6.2.1 https://github.com/travis-ci/worker/tree/4e3246c044eb4915c2378ffacd0b3d3ed0136bba
instance: travis-job-57dbae5a-406f-4d29-8ac3-134bb4a43b33 travis-ci-sardonyx-xenial-1553530528-f909ac5 (via amqp)
startup: 6.949071797s
system_info
Build system information
Build language: php
Build group: stable
Build dist: xenial
Build id: 564288674
Job id: 564288675
Runtime kernel version: 4.15.0-1028-gcp
travis-build version: 24c88d12b
Build image provisioning date and time
Mon Mar 25 16:43:24 UTC 2019
Operating System Details
Distributor ID:	Ubuntu
Description:	Ubuntu 16.04.6 LTS
Release:	16.04
Codename:	xenial
Systemd Version
systemd 229
Cookbooks Version
42e42e4 https://github.com/travis-ci/travis-cookbooks/tree/42e42e4
git version
git version 2.21.0
bash version
GNU bash, version 4.3.48(1)-release (x86_64-pc-linux-gnu)
gcc version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.11) 5.4.0 20160609
docker version
Client:
 Version:           18.06.0-ce
 API version:       1.38
 Go version:        go1.10.3
 Git commit:        0ffa825
 Built:             Wed Jul 18 19:11:02 2018
 OS/Arch:           linux/amd64
 Experimental:      false
Server:
 Engine:
  Version:          18.06.0-ce
  API version:      1.38 (minimum version 1.12)
  Go version:       go1.10.3
  Git commit:       0ffa825
  Built:            Wed Jul 18 19:09:05 2018
  OS/Arch:          linux/amd64
  Experimental:     false
clang version
clang version 7.0.0 (tags/RELEASE_700/final)
jq version
jq-1.5
bats version
Bats 0.4.0
shellcheck version
0.6.0
shfmt version
v2.6.3
ccache version
3.2.4
cmake version
cmake version 3.12.4
heroku version
heroku/7.22.7 linux-x64 node-v11.10.1
imagemagick version
Version: ImageMagick 6.8.9-9 Q16 x86_64 2018-09-28 http://www.imagemagick.org
md5deep version
4.4
mercurial version
version 4.8
mysql version
mysql  Ver 14.14 Distrib 5.7.25, for Linux (x86_64) using  EditLine wrapper
openssl version
OpenSSL 1.0.2g  1 Mar 2016
packer version
1.3.3
postgresql client version
psql (PostgreSQL) 10.7 (Ubuntu 10.7-1.pgdg16.04+1)
ragel version
Ragel State Machine Compiler version 6.8 Feb 2013
sudo version
1.8.16
gzip version
gzip 1.6
zip version
Zip 3.0
vim version
VIM - Vi IMproved 7.4 (2013 Aug 10, compiled Nov 24 2016 16:44:48)
iptables version
iptables v1.6.0
curl version
curl 7.47.0 (x86_64-pc-linux-gnu) libcurl/7.47.0 GnuTLS/3.4.10 zlib/1.2.8 libidn/1.32 librtmp/2.3
wget version
GNU Wget 1.17.1 built on linux-gnu.
rsync version
rsync  version 3.1.1  protocol version 31
gimme version
v1.5.3
nvm version
0.34.0
perlbrew version
/home/travis/perl5/perlbrew/bin/perlbrew  - App::perlbrew/0.86
phpenv version
rbenv 1.1.2
rvm version
rvm 1.29.7 (latest) by Michal Papis, Piotr Kuczynski, Wayne E. Seguin [https://rvm.io]
default ruby version
ruby 2.5.3p105 (2018-10-18 revision 65156) [x86_64-linux]
CouchDB version
couchdb 1.6.1
ElasticSearch version
5.5.0
Installed Firefox version
firefox 63.0.1
MongoDB version
MongoDB 4.0.7
PhantomJS version
2.1.1
Pre-installed PostgreSQL versions
9.4.21
9.5.16
9.6.12
Redis version
redis-server 5.0.4
Pre-installed Go versions
1.11.1
mvn version
Apache Maven 3.6.0 (97c98ec64a1fdfee7767ce5ffb20918da4f719f3; 2018-10-24T18:41:47Z)
gradle version
Gradle 4.10.2!
lein version
Leiningen 2.9.1 on Java 11.0.2 OpenJDK 64-Bit Server VM
Pre-installed Node.js versions
v10.15.3
v11.0.0
v4.9.1
v6.17.0
v8.12.0
v8.15.1
v8.9
phpenv versions
  system
  5.6
  5.6.40
  7.1
  7.1.27
  7.2
* 7.2.15 (set by /home/travis/.phpenv/version)
  hhvm
  hhvm-stable
composer --version
Composer version 1.8.4 2019-02-11 10:52:10
Pre-installed Ruby versions
ruby-2.3.8
ruby-2.4.5
ruby-2.5.3
docker_mtu
resolvconf
git.checkout
0.68s$ git clone --depth=50 --branch=master https://github.com/danbelden/open-exchange-rates.git danbelden/open-exchange-rates
Cloning into 'danbelden/open-exchange-rates'...
$ cd danbelden/open-exchange-rates
$ git checkout -qf ca474ca3a179024fea6d945f38643c2b59ca6f47
Setting environment variables from repository settings
$ export APP_ID=[secure]
0.02s$ phpenv global 5.4 2>/dev/null
5.4 is not pre-installed; installing
Downloading archive: https://storage.googleapis.com/travis-ci-language-archives/php/binaries/ubuntu/16.04/x86_64/php-5.4.tar.bz2
0.12s$ curl -s -o archive.tar.bz2 $archive_url && tar xjf archive.tar.bz2 --directory /
bzip2: (stdin) is not a bzip2 file.
tar: Child returned status 2
tar: Error is not recoverable: exiting now
0.00s0.02s$ phpenv global 5.4
rbenv: version `5.4' not installed
The command "phpenv global 5.4" failed and exited with 1 during .
Your build has been stopped.
```